### PR TITLE
When there's a callID for A leg, build the call flow with both legs

### DIFF
--- a/js/modules/pages/controllers/resultCtrl.js
+++ b/js/modules/pages/controllers/resultCtrl.js
@@ -184,6 +184,8 @@
 
 		callids.push(localrow.entity.callid);
 
+		if(callids.indexOf(localrow.entity.callid_aleg) == -1 && localrow.entity.callid_aleg.length > 1) callids.push(localrow.entity.callid_aleg);
+
 		angular.forEach(rows, function(row, key) {
 		    if(callids.indexOf(row.callid) == -1) callids.push(row.callid);
 		    if(callids.indexOf(row.callid_aleg) == -1 && row.callid_aleg.length > 1) callids.push(row.callid_aleg);


### PR DESCRIPTION
In the Search results, I'd like to click on a Call ID and, if there's a Call ID for the A leg associated, see the call flow with both legs.
