### PR TITLE
Update homer.min.css

### DIFF
--- a/css/homer.min.css
+++ b/css/homer.min.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);@import url(http://fonts.googleapis.com/css?family=Kaushan+Script);/*! 
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,300italic,400italic,600italic);@import url(https://fonts.googleapis.com/css?family=Kaushan+Script);/*! 
  *   HOMER 5.0
  *   Author: Alexandr Dubovikov
  *   License: AGPLv3


### PR DESCRIPTION
Use https for google fonts. Eliminates warning when Homer is on an SSL site.