### PR TITLE
Fixed dialogCtrl.js typo

### DIFF
--- a/js/modules/pages/controllers/dialogCtrl.js
+++ b/js/modules/pages/controllers/dialogCtrl.js
@@ -490,7 +490,7 @@
 
 					// RTCP
 					try {
-					  if(msg.reports.lenght > 0) { 					
+					  if(msg.reports.length != 0) { 					
 
 					            var charts = {};
 						    if(msg.reports.rtcp && msg.reports.rtcp.chart) {


### PR DESCRIPTION
When reports has some info is not an array, so its lenth cannot be 0.