### PR TITLE
Add status_code as filter for Destination stats widget

### DIFF
--- a/js/widgets/datasource.js
+++ b/js/widgets/datasource.js
@@ -253,6 +253,7 @@ var datasource_h5 = {
 					{ "type": "country", "desc": "Destination Country", options: [ {"value": "ALL"}  ] },
 					{ "type": "prefix", "desc": "Destination Prefix", options: [ {"value": "ALL"}  ] },
 					{ "type": "method", "desc": "SIP Method", options: [ {"value": "ALL"}  ] },
+					{ "type": "status_code", "desc": "SIP Status Code", options: [ {"value": "ALL"}  ] },
                 ]
             }
         }


### PR DESCRIPTION
This is part of 3 PRs involving homer-docker (kamailio.cfg), homer-api (api/RestApi/Statistic.php) and homer-ui (js/widgets/datasource.js).

The objective is to distinguish, in Destination Stats, responses associated to different methods, e.g. a 200 to INVITE from a 200 to BYE.