### PR TITLE
Add favicon link, update assets/images references

### DIFF
--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -2,7 +2,7 @@
     <mat-card-header>
         <mat-card-title>
             <div class="login-page-header">
-                <img src="/assets/images/homerseven.png" />
+                <img src="assets/images/homerseven.png" />
                 <h2>Homer Login</h2>
             </div>
         </mat-card-title>

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar color="primary" class="header">
 	<div class="logo-base" (click)="backLastToDashboard()">
-		<img src="/assets/images/homerseven.png" />
+		<img src="assets/images/homerseven.png" />
 		<div class="logo-text">homer</div>
 	</div>
 	<div>

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <base href="/" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
     <title>HOMER</title>
     <meta http-equiv="Access-Control-Allow-Origin" content="*">
     <meta name="viewport" content="width=device-width, initial-scale=0.8, maximum-scale=1.0, user-scalable=no" />
@@ -99,7 +100,7 @@
 <body>
     <app-root>
         <div class="loader-container">
-            <img  src="/assets/images/homerseven.png">
+            <img src="assets/images/homerseven.png">
             <div class="spiner">
                 <svg preserveAspectRatio="xMidYMid meet" focusable="false" ng-reflect-ng-switch="true" viewBox="0 0 100 100">
                     <circle cx="50%" cy="50%" r="45"></circle>


### PR DESCRIPTION
Per the discussion in sipcapture/homer-app, https://github.com/sipcapture/homer-app/issues/321, this  would allow users like myself to use a subpath when connecting to HOMER v7.  There might be a handful (or maybe a lot) of people that will need to run HOMER v5 and v7 on the same server.

If you prefer to use `./assets/images` instead of `assets/images` I can make the changes.

One thing to note, as you probably already know, with this change the .js and index.html files must reside in the same directory as assets.  That shouldn't be a problem since your build script puts those files in the correct location.