### PR TITLE
Typo fixed

### DIFF
--- a/src/app/components/controls/loki-results/loki-results.component.html
+++ b/src/app/components/controls/loki-results/loki-results.component.html
@@ -1,4 +1,4 @@
-<div clas="loki-main-container"
+<div class="loki-main-container"
     style="display: flex;background:white">
     <div style="flex:1;padding:12px;padding-bottom:5px;">
         <app-code-style-field [queryText]="queryText"


### PR DESCRIPTION
Missing "s" in class property name of loki-main-container in loki-results template.