### PR TITLE
add new Capture-ID message consolidation feature

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,15 @@
+# OPTIONAL; use this Dockerfile for local development:
+#   1. docker build -t homer-ui -f ./Dockerfile.local .
+#   2. cd /path/to/homer-app
+#   3. make localfe
+
+FROM node:18-alpine
+
+RUN apk add git
+
+COPY . /app/
+WORKDIR /app
+
+RUN npm install && npm install -g @angular/cli
+RUN npm run build
+#RUN ng build

--- a/src/app/components/controls/transaction-filter/transaction-filter.component.html
+++ b/src/app/components/controls/transaction-filter/transaction-filter.component.html
@@ -31,8 +31,9 @@
             {{type.value}}
         </mat-radio-button>
     </mat-radio-group>
+
     <div style="margin: 0 -10px 5px -10px;">
-        <mat-accordion>
+        <mat-accordion>            
             <mat-expansion-panel [expanded]="true">
                 <mat-expansion-panel-header>
                     <mat-panel-title>PayloadType</mat-panel-title>
@@ -47,6 +48,29 @@
                     </ng-container>
                 </div>
             </mat-expansion-panel>
+            <mat-expansion-panel *ngIf="(isFlowTab && (hasFingerprints$ | async)) as hasFingerprints">
+                <mat-expansion-panel-header>
+                    <mat-panel-title>
+                        Capture ID Consolidation
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                <mat-slide-toggle class="slide-toggle"
+                    *ngIf="hasFingerprints"
+                    color="primary"
+                    [(ngModel)]="isConsolidateCaptureIds"
+                    (click)="doFilterMessages()">
+                    Enable
+                </mat-slide-toggle>
+                <br *ngIf="hasFingerprints">
+                <mat-form-field *ngIf="hasFingerprints" class="example-full-width">
+                    <mat-label>Threshold (ms)</mat-label>
+                    <input matInput type="number" min="100" max="10000" step="100"
+                        [(ngModel)]="consolidationTimeThreshold"
+                        [disabled]="!isConsolidateCaptureIds"
+                        placeholder="Enter time threshold"
+                        (change)="doFilterMessages()">
+                </mat-form-field>
+            </mat-expansion-panel>            
             <mat-expansion-panel *ngIf="checkboxListFilterAliases.length">
                 <mat-expansion-panel-header>
                     <mat-panel-title>Alias filter</mat-panel-title>

--- a/src/app/components/search-grid-call/detail-dialog/tab-flow/flow-item/flow-item.component.html
+++ b/src/app/components/search-grid-call/detail-dialog/tab-flow/flow-item/flow-item.component.html
@@ -1,4 +1,4 @@
-<div class="item-flow-packet-container">
+<ng-template #itemFlowPacket let-item="item" let-idx="idx" >
   <div class="bg-color-polygon"
     [style.background-color]="item.options.color"></div>
   <!-- background-color -->
@@ -6,20 +6,22 @@
   <div [style.flex]="item.options.start || 0.0000001"></div>
   <!-- left space -->
   <div class="item-flow-packet"
-    (click)="onClickItem(idx, $event)"
+    (click)="onClickItem(item, idx, $event)"
     [style.flex]="item.options.middle || 0.0000001"
     [style.text-align]="item.options.direction ? 'right' : 'left'">
 
     <!-- content -->
     <div class="call_text"
       [style.color]="item.options.color_method || 'initial'">
+      <span *ngIf="item.subItems && item.subItems.length > 0" [style.opacity]="0.6" (click)="toggleSubItems($event)">
+        {{ showSubItems ? '▽' : '▷' }}
+      </span>
       {{ item.method_text }}
       <span *ngIf="item.QOS && item.QOS.MOS"
         class="blinkLamp"
         [style.backgroundColor]="MOSColorGradient(item.QOS.MOS)"></span>
       {{ item.QOS ? (item.QOS.MOS ? (item.QOS.MOS + " [" + item.QOS.qosTYPEless + "]") : 'UA Report') : "" }}
     </div>
-
 
     <div class="call_text-mini"
       [style.height.px]=" !isSimplify ? 15 : 0 ">
@@ -65,4 +67,12 @@
   <div
     [style.flex]="(item.options.rightEnd - (item.options.isRadialArrow && !item.options.isLastHost ? 1 : 0 )) || 0.0000001">
   </div>
+</ng-template>
+<div class="item-flow-packet-container">
+  <ng-container *ngTemplateOutlet="itemFlowPacket; context: { item: item, idx: idx }"></ng-container>
+</div>
+<div class="item-flow-packet-container" *ngIf="showSubItems && item.subItems && item.subItems.length > 0">
+  <ng-container *ngFor="let subItem of item.subItems; let subIdx = index">
+    <ng-container *ngTemplateOutlet="itemFlowPacket; context: { item: subItem, idx: idx }"></ng-container>
+  </ng-container>
 </div>

--- a/src/app/components/search-grid-call/detail-dialog/tab-flow/flow-item/flow-item.component.ts
+++ b/src/app/components/search-grid-call/detail-dialog/tab-flow/flow-item/flow-item.component.ts
@@ -9,6 +9,8 @@ import {
   ChangeDetectorRef,
 } from '@angular/core';
 import { Functions } from '@app/helpers/functions';
+import { Subscription } from 'rxjs';
+import { CallCaptureIdConsolidationService } from '@app/services/call/consolidation.service';
 
 @Component({
   selector: 'app-flow-item',
@@ -18,8 +20,14 @@ import { Functions } from '@app/helpers/functions';
 })
 export class FlowItemComponent implements AfterViewChecked {
   _item: any = {};
+  showSubItems: boolean = false;
+
+  consolidationFilterSubscription: Subscription;
+  expandedItemSubscription: Subscription;
+
   @Input() set item(val: any) {
     this._item = val;
+    this.mergeOptions();
   }
   get item(): any {
     return this._item;
@@ -28,16 +36,50 @@ export class FlowItemComponent implements AfterViewChecked {
   @Input() isGroupByAlias = false;
   @Input() idx = 0;
   @Input() isAbsolute: boolean = false;
-  @Output() itemClick: EventEmitter<any> = new EventEmitter();
+  @Output() itemClick: EventEmitter<{ idx: number, event: any, item: any }> = new EventEmitter();
 
-  constructor(private cdr: ChangeDetectorRef) { }
+  constructor(
+    private cdr: ChangeDetectorRef, 
+    private consolidationService: CallCaptureIdConsolidationService) {}
 
-  onClickItem(idx, event) {
-    this.itemClick.emit({ idx, event });
+  ngOnInit() {
+    this.expandedItemSubscription = this.consolidationService.expandedItem$.subscribe(expandedIdx => {
+      if (expandedIdx !== this.idx && this.showSubItems) {
+        this.showSubItems = false;
+        this.cdr.detectChanges();
+      }
+    });
+  }
+
+  ngOnDestory() {
+    if (this.consolidationFilterSubscription) this.consolidationFilterSubscription.unsubscribe();
+    if (this.expandedItemSubscription) this.expandedItemSubscription.unsubscribe();
+  }
+
+  onClickItem(item, idx, event) {
+    this.itemClick.emit({ idx, event, item });
+  }
+
+  toggleSubItems(event: Event) {
+    event.stopPropagation(); // Prevent triggering the onClickItem event
+    this.showSubItems = !this.showSubItems;
+    if (this.showSubItems) {
+      this.consolidationService.setExpandedItem(this.idx);
+    }    
   }
 
   MOSColorGradient(hue) {
     return Functions.MOSColorGradient(hue * 100, 80, 50);
+  }
+
+  private mergeOptions() {
+    if (this._item && this._item.subItems) {
+      this._item.subItems = this._item.subItems.map((subItem, iter) => ({
+        ...subItem,
+        options: this._item.options,
+        __item__subindex__: iter
+      }));
+    }
   }
 
   ngAfterViewChecked() {

--- a/src/app/components/search-grid-call/detail-dialog/tab-flow/tab-flow.component.html
+++ b/src/app/components/search-grid-call/detail-dialog/tab-flow/tab-flow.component.html
@@ -154,7 +154,7 @@
                 [isGroupByAlias]="_isCombineByAlias"
                 [isSimplify]="isSimplify"
                 [isAbsolute]="false"
-                (itemClick)="onClickMessage($event.idx, $event.event, item)"
+                (itemClick)="onClickMessage($event.idx, $event.event, $event.item)"
             ></app-flow-item>
             <div style="height: 60px"></div>
         </div>
@@ -189,7 +189,7 @@
             [isGroupByAlias]="_isCombineByAlias"
             [isSimplify]="isSimplify"
             [isAbsolute]="false"
-            (itemClick)="onClickMessage($event.idx, $event.event, item)"
+            (itemClick)="onClickMessage($event.idx, $event.event, $event.item)"
           >
           </app-flow-item>
         </ng-template>

--- a/src/app/components/search-grid-call/message-content/message-content.component.html
+++ b/src/app/components/search-grid-call/message-content/message-content.component.html
@@ -65,7 +65,7 @@
             <td mat-cell *matCellDef="let element"
               style="font-size:12px;font-family: 'Roboto Mono', monospace !important;">
               <div *ngIf="isObject(element.value); else simpleType">
-                <ngx-json-viewer [json]="{details: element.value}" [expanded]="true"></ngx-json-viewer>
+                <ngx-json-viewer [json]="{details: element.value}" [expanded]="true"></ngx-json-viewer>                
               </div>
               <ng-template #simpleType>
                 <span style="font-size:12px;font-family: 'Roboto Mono', monospace !important;">{{element.value}}</span>

--- a/src/app/components/search-grid-call/message-content/message-content.component.ts
+++ b/src/app/components/search-grid-call/message-content/message-content.component.ts
@@ -8,6 +8,7 @@ import jwt_decode from 'jwt-decode';
 import { AlertService } from '@app/services/alert.service';
 import { TranslateService } from '@ngx-translate/core';
 import { DateFormat, TimeFormattingService } from '@app/services/time-formatting.service';
+import { Subscription } from 'rxjs';
 
 const parsip = _parsip;
 // const moment = _moment;
@@ -39,12 +40,12 @@ export class MessageContentComponent implements OnInit, OnDestroy, AfterViewInit
     this._pt = v;
   }
 
-
   @ViewChild('matTabGroup', { static: false }) matTabGroup: MatTabGroup;
   @Input() rowData: any;
   @Input() set isDecoded(val: boolean) {
     this.cdr.detectChanges()
-  }
+  }  
+
   @Input('data') set data(val) {
     this._data = Functions.cloneObject(val);
     // console.log('this._data', this._data);
@@ -158,7 +159,6 @@ export class MessageContentComponent implements OnInit, OnDestroy, AfterViewInit
     private _tfs: TimeFormattingService,
     public alertService: AlertService,
     public translateService: TranslateService
-
   ) { }
 
   identify(index, item) {
@@ -174,7 +174,6 @@ export class MessageContentComponent implements OnInit, OnDestroy, AfterViewInit
     this._interval = setInterval(() => {
       this.matTabGroup?.realignInkBar();
     }, 2000);
-
   }
   ngAfterViewInit() {
     this.matTabGroup?.realignInkBar();
@@ -213,6 +212,5 @@ export class MessageContentComponent implements OnInit, OnDestroy, AfterViewInit
   }
   objString(s) {
     return JSON.stringify(s, null, 4);
-  }
-
+  }  
 }

--- a/src/app/services/call/consolidation.service.ts
+++ b/src/app/services/call/consolidation.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { tap, takeUntil } from 'rxjs/operators';
+@Injectable({
+  providedIn: 'root'
+})
+
+export class CallCaptureIdConsolidationService implements OnDestroy {
+  private consolidationFilterSubject = new BehaviorSubject<{isConsolidateCaptureIds: boolean, consolidationTimeThreshold: number}>({isConsolidateCaptureIds: false, consolidationTimeThreshold: 500});
+  done$ = new Subject<void>();
+
+  consolidationFilter$ = this.consolidationFilterSubject.asObservable();
+
+  ngOnDestroy() {
+    this.done$.next();
+    this.done$.complete();
+  }
+
+  setConsolidationFilter(value: any) {
+    this.done$.next();
+    this.consolidationFilterSubject.next(value);
+  }
+
+  private expandItemSubject = new Subject<number>();
+  expandedItem$ = this.expandItemSubject.asObservable();
+
+  setExpandedItem(idx: number) {
+    this.expandItemSubject.next(idx);
+  }
+
+  consolidateMessages(messages: any[]) {
+    const {isConsolidateCaptureIds, consolidationTimeThreshold} = this.consolidationFilterSubject.getValue();
+    const stopProcessing$ = this.done$.asObservable();
+    let finished = false;
+
+    // Check if processing should be stopped
+    const unsubscribe$ = new Subject<void>();
+    stopProcessing$.pipe(takeUntil(unsubscribe$)).subscribe(() => {
+      finished = true;
+    });      
+
+    const fingerprintGroups: Map<string, any[]> = new Map();
+
+    for (let item of messages) {
+      if (finished) {
+        // aborting early!
+        unsubscribe$.next();
+        unsubscribe$.complete();
+        return messages;
+      }
+
+      item.isConsolidated = false;
+      if (item.subItems) {
+        delete item.subItems;
+      }
+
+      if (!isConsolidateCaptureIds) {
+        continue;
+      }
+
+      const messageDataItem = item.messageData?.item;
+      if (!messageDataItem) {
+        continue;
+      }
+
+      const fingerprint = messageDataItem.fingerprint;
+      if (!fingerprint) {
+        continue;
+      }
+
+//      let groups = fingerprintGroups.get(fingerprint) || [];
+
+      let groups = fingerprintGroups.get(fingerprint);
+      if (!groups) {
+        groups = [];
+        fingerprintGroups.set(fingerprint, groups);
+      }
+
+      const parentItem = groups.find(parent => 
+        this.canBeConsolidated(item, parent, consolidationTimeThreshold)
+      );
+
+      if (parentItem) {
+        if (!parentItem.subItems) {
+          parentItem.subItems = [];
+        }
+        
+        parentItem.subItems.push(item);
+        item.isConsolidated = true;
+      } else {
+        groups.push(item);
+      }
+
+      fingerprintGroups.set(fingerprint, groups);
+    }
+
+    unsubscribe$.next();
+    unsubscribe$.complete();
+    return messages;
+  }
+
+  private canBeConsolidated(item: any, parentItem: any, timeThreshold: number): boolean {
+    const parentCaptureId = parentItem.messageData?.item?.captureId;
+    const thisCaptureId = item.messageData?.item?.captureId;
+    
+    // Time threshold check
+    const timeDiff = Math.abs(item.micro_ts - parentItem.micro_ts);
+    if (timeDiff > timeThreshold) {
+      return false;
+    }
+    
+    // Parent and current item should have different captureIds
+    if (parentCaptureId === thisCaptureId) {
+      return false;
+    }
+    
+    // Check if captureId already exists in subItems
+    if (parentItem.subItems?.some(subItem => 
+      subItem.messageData?.item?.captureId === thisCaptureId)) {
+      return false;
+    }
+    
+    // All checks passed, can be consolidated
+    return true;
+  }
+}


### PR DESCRIPTION
This change allows the UI to group and filter the Flow tab such that all messages with the same fingerprint but from different Capture IDs are presented as one (with a drop down to access the individual messages).

This provides for clarity and a simplified sequence chart as multiple capture IDs merely indicate multiple capture clients seeing the same message and not message duplication that requires investigation.

To use this feature, you need to generate a fingerprint for your messages. This can be done using lua in heplify-server:
```
function checkRAW()
	local protoType = GetHEPProtoType()

	-- Check if we have SIP type 
	if protoType ~= 1 then
		return
	end

	-- original SIP message Payload
	local raw = GetRawMessage()

	-- get source and destination from HEP protocol
	local srcIP, srcPort = GetHEPSrcIP(), GetHEPSrcPort()
	local dstIP, dstPort = GetHEPDstIP(), GetHEPDstPort()

	-- create a fingerprint for the sip message
	local hashBody = string.format("%s:%s-%s:%s-%s", srcIP, srcPort, dstIP, dstPort, raw)
	local sum = HashString("sha256", hashBody)
	SetSIPHeader("fingerprint", sum)

	return
end
```

![Screenshot 2025-02-27 at 13 20 24](https://github.com/user-attachments/assets/a3db6c86-71c5-41bb-a26e-3ae9de9cd02b)

the feature will only be available in the filter tab if the data in the flow tab actually contains a fingerprint.