### PR TITLE
Fixed up OAuth button layout to be clearer to end users

### DIFF
--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -61,20 +61,24 @@
 
         <button mat-flat-button
           class="login-submit">{{ 'login.signInButton' | translate }}</button>
-        <span class="oauth-wrapper" *ngIf="oAuthTypes?.length > 0"
-        [style.min-height.px]="oAuthTypes?.length > 5 ? 100 : 50"
-        [style.max-height.px]="oAuthTypes?.length > 5 ? 100 : 50"
-        >
+        
+    <div *ngIf="oAuthTypes?.length > 0">
+      <div class="oauth-divider">or continue with</div>
+            <div class="oauth-wrapper">
             <span class="oauth-button-wrapper" *ngFor="let type of oAuthTypes">
                 <button mat-flat-button class="oauth-submit"
                 [style.background-color]="type.color || 'hsl(0, 0%, 50%)'"
                 (click)='goOauth(type)'
                 >
-                    <fa-icon *ngIf="type.provider_name && !type.provider_image" [icon]="['fab', type.provider_name]"></fa-icon>
-                    <img *ngIf="type.provider_image" [src]="type.provider_image" width="20" height="20">
+                    <span class="oauth-icon">
+                      <fa-icon *ngIf="type.provider_name && !type.provider_image" [icon]="['fab', type.provider_name]"></fa-icon>
+                      <img *ngIf="type.provider_image" [src]="type.provider_image" width="20" height="20">
+                    </span>
+                    <span class="oauth-label">{{ type.name }}</span>
                 </button>
             </span>
-        </span>
+      </div>
+    </div>
       </form>
       <!-- <ng-template #noApiResponse> -->
       <div *ngIf="typesError && !translateError"

--- a/src/app/components/login/login.component.scss
+++ b/src/app/components/login/login.component.scss
@@ -31,32 +31,99 @@
   cursor: pointer;
   float: right;
 }
-.oauth-submit {
-    display: inline-block !important;
-    border: none;
-    border-radius: 3px;
-    padding: 0 !important;
-    min-width: unset !important;
-    width: 40px !important;
-    height: 40px;
-    color: white;
-    font-size: 20px;
-    cursor: pointer;
-}
-.oauth-wrapper {
-    margin-top: 10px;
+
+  .oauth-divider {
     display: flex;
-    justify-content: space-evenly;
-    flex-wrap: wrap;
+    align-items: center;
+    text-align: center;
+    margin: 25px 0 20px 0;
+    color: #666;
+    font-size: 13px;
+    
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      border-bottom: 1px solid #ddd;
+    }
+    
+    &::before {
+      margin-right: 15px;
+    }
+    
+    &::after {
+      margin-left: 15px;
+    }
+  }
+
+  .oauth-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
     width: 100%;
-    row-gap: 10px;
-    overflow: scroll;
-}
-.oauth-button-wrapper {
-    flex: 0 0 20%;
+    padding: 0;
+  }
+
+  .oauth-button-wrapper {
+    width: 100%;
     display: flex;
     justify-content: center;
-}
+  }
+
+  .oauth-submit {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    border: 1px solid #ddd !important;
+    border-radius: 5px;
+    padding: 10px 20px !important;
+    min-width: unset !important;
+    width: 100% !important;
+    height: 45px;
+    color: white !important;
+    font-size: 15px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    // Ensure Angular Material's inner wrapper lays out icon + text with spacing
+    .mat-button-wrapper {
+      display: inline-flex;
+      align-items: center;
+      gap: 14px;
+      width: 100%;
+      justify-content: center;
+    }
+    
+  // Fixed-width icon box to ensure breathing room before label
+  .oauth-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px; // keeps label from crowding icon
+    height: 20px;
+    margin-right: 10px; // explicit extra space
+    flex-shrink: 0;
+  }
+  .oauth-label {
+    line-height: 20px;
+  }
+    
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    }
+    
+    &:active {
+      transform: translateY(0);
+    }
+    
+    fa-icon {
+      font-size: 20px;
+    }
+  }
+
 .login-logo {
   margin-bottom: 36px;
   img {


### PR DESCRIPTION
Hi.

We use OAuth logins on the homer webapp. However, we found that using a custom OAuth provider led to a button that was not clear enough for end users. They would try to log in with the existing login form. I've improved the login buttons for social and OAuth applications to make it clearer to use those if they are available. 
<img width="660" height="768" alt="Screenshot 2025-11-16 at 14 27 07" src="https://github.com/user-attachments/assets/2d7d21af-b6a2-4f2a-9bfe-70e79912b7ef" />

